### PR TITLE
Add files via upload

### DIFF
--- a/front/tickets/tickets.php
+++ b/front/tickets/tickets.php
@@ -113,11 +113,38 @@ Session::checkRight("profile", READ);
 		$abertos = $data['total']; 
 		
 		//insert if not exist entity
-		$query_i = "
-		INSERT IGNORE INTO glpi_plugin_dashboard_count (type, id, quant) 
-		VALUES ('1','". $ent ."', '" . $abertos ."')  ";
+		//$query_i = "
+		//INSERT IGNORE INTO glpi_plugin_dashboard_count (type, id, quant) 
+		//VALUES ('1','". $ent ."', '" . $abertos ."')  ";
 		
-		$result_i = $DB->query($query_i);
+		//$result_i = $DB->query($query_i);
+		//
+		
+		// Adicionado por Rogerio para resolver erros de SQL causados pelo dashboard
+		// Assuming $ent is a comma-separated list of entity IDs
+		$entities = explode(',', $ent);
+
+		foreach ($entities as $singleEnt) {
+		    $singleEnt = trim($singleEnt); // Remove any whitespace
+		    // Optionally, cast to integer to ensure proper format:
+		    $singleEnt = (int)$singleEnt;
+
+		    //$query_i = "INSERT IGNORE INTO glpi_plugin_dashboard_count (type, id, quant)
+		    //            VALUES ('1', '$singleEnt', '$abertos')";
+
+		   $query_i = "
+				INSERT INTO glpi_plugin_dashboard_count (type, id, quant)
+				VALUES ('1', '".$singleEnt."', '".$abertos."')
+				ON DUPLICATE KEY UPDATE quant = VALUES(quant)";
+
+
+		    $result_i = $DB->query($query_i);
+		    if (!$result_i) {
+		        // Optionally log the error for further debugging
+		        error_log("Failed to insert entity ID $singleEnt: " . $DB->error());
+		    }
+		}
+
 		
 		// get quantity
 		$query = "SELECT quant 


### PR DESCRIPTION
Fixed bug present from lines 115 to 120.
When dealing with multiple Entities, GLPI creates different IDs for each one. So, the original tickets.php code returned "$ent" as a comma-separated string list. The expected value is only the Entity numeric value. This caused the following error on sql-errors.log: "[2024-09-24 16:42:05] glpisqllog.WARNING: DBmysql::query() in /srv/www/glpi/src/DBmysql.php line 404
  *** MySQL query warnings:
  SQL:
                INSERT IGNORE INTO glpi_plugin_dashboard_count (type, id, quant)
                VALUES ('1','0,64,1,58,95,97,75,31,18,137,7,17,9,14,29,36,35,37,38,43,44,47,48,111,39,54,51,91,57,126,19,88,121,127,104,122,123,124,68,125,132,134,136,99,129,130,107,81,120,84,135,133,82,128,93,115,131,100,96,98,138,139,140', '61')
  Warnings:
1265: Data truncated for column 'id' at row 1
1062: Duplicate entry '0' for key 'PRIMARY'
  Backtrace :
  plugins/dashboard/front/tickets/tickets.php:120
  public/index.php:90                                require()
  {"user":"599@sja-vssd01"}
"
The following changes were made to the code:
1. Added a routine to treat each comma-separated entity to a single numeric value
2. For each entity, the SQL query was changed to insert data correctly
3. Query at "$query_i" was changed to update "quant" column according to the entity.