### PR TITLE
Add files via upload

### DIFF
--- a/front/tickets/tickets_ent.php
+++ b/front/tickets/tickets_ent.php
@@ -96,9 +96,14 @@ Session::checkRight("profile", READ);
 			$abertos = $data['total']; 
 			
 			//insert if not exist entity
-			$query_i = "
-			INSERT IGNORE INTO glpi_plugin_dashboard_count (type, id, quant) 
-			VALUES ('2','". $ent ."', '" . $abertos ."')  ";
+			//$query_i = "
+			//INSERT IGNORE INTO glpi_plugin_dashboard_count (type, id, quant) 
+			//VALUES ('2','". $ent ."', '" . $abertos ."')  ";
+                        $query_i = "
+                        INSERT INTO glpi_plugin_dashboard_count (type, id, quant)
+			VALUES ('2','". $ent ."', '" . $abertos ."')
+			ON DUPLICATE KEY UPDATE quant = VALUES(quant)";
+
 			
 			$result_i = $DB->query($query_i);
 			


### PR DESCRIPTION
In original tickets_ent.php file, from line 103, is established the following SQL query: "			$query_i = "
			INSERT IGNORE INTO glpi_plugin_dashboard_count (type, id, quant) 
			VALUES ('2','". $ent ."', '" . $abertos ."')  ";
"
This query is valid, but glpi_plugin_dashboard_count table has the "id" column set to be a primary key. So, the SQL command "INSERT IGNORE", despite to the fact that it ignores the duplicate entries in table, it returns the following SQL warning on sql-errors.log:

"[2025-02-04 14:54:51] glpisqllog.WARNING: DBmysql::query() in /srv/www/vhosts/glpi/src/DBmysql.php line 404
  *** MySQL query warnings:
  SQL:
                        INSERT IGNORE INTO glpi_plugin_dashboard_count (type, id, quant)
                        VALUES ('2','0', '13')
  Warnings:
1062: Duplicate entry '0' for key 'PRIMARY'
  Backtrace :
  ...ins/dashboard/front/tickets/tickets_ent.php:103
  public/index.php:90                                require()
  {"user":"208@sja-vssd01"}
"

I updated this query to:

"                        $query_i = "
                        INSERT INTO glpi_plugin_dashboard_count (type, id, quant)
			VALUES ('2','". $ent ."', '" . $abertos ."')
			ON DUPLICATE KEY UPDATE quant = VALUES(quant)";
"
This change makes the insert only on column's "quant" values, avoiding the above warning messages.